### PR TITLE
Normalize line endings to LF, style: 공통 css 파일 추가

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,10 @@
-* text eol=lf
+# * text eol=lf
 
-# (선택) Windows 전용 스크립트는 CRLF 유지
-*.bat text eol=crlf
-*.ps1 text eol=crlf
+# # (선택) Windows 전용 스크립트는 CRLF 유지
+# *.bat text eol=crlf
+# *.ps1 text eol=crlf
+
+* text=auto
+*.css text eol=lf
+*.js text eol=lf
+*.md text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.eslintcache
+.eslintcache.*

--- a/src/assets/styles/colors.css
+++ b/src/assets/styles/colors.css
@@ -1,0 +1,42 @@
+@import 'tailwindcss';
+
+@theme {
+  /* colors */
+
+  /*text*/
+  --color-text-default: #f6f6f6;
+  --color-text-active: #ff5126;
+  --color-text-support: #888888;
+  --color-text-disabled: #5e5e5e;
+
+  /* icon */
+  --color-icon-default: #888888;
+  --color-icon-active: #ff5126;
+
+  /* background */
+  --color-bg-main: #121212;
+  --color-bg-input: #292929;
+  --color-bg-button: #292929;
+  --color-bg-board: #1f1f1f;
+
+  /* border */
+  --color-border: #292929;
+  --color-input-active: rgba(255, 81, 38, 0.7);
+}
+
+@theme {
+  /* font-size */
+  --text-h1: 1.5rem; /* 24px */
+  --text-h2: 1.25rem; /* 20px */
+  --text-body1: 1.125rem; /* 18px */
+  --text-body2: 1rem; /* 16px */
+  --text-body3: 0.875rem; /* 14px */
+  --text-body4: 0.75rem; /* 12px */
+}
+
+@media (width >= 480px) {
+  @theme {
+    --text-h1: 1.75rem; /* 28px */
+    --text-h2: 1.375rem; /* 22px */
+  }
+}

--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -1,0 +1,10 @@
+@import './colors.css';
+
+html,
+body {
+  background-color: var(--color-bg-main);
+}
+
+button {
+  cursor: pointer;
+}


### PR DESCRIPTION
git add 할 때 

warning: in the working copy of '.gitattributes', CRLF will be replaced by LF the next time Git touches it
해당 경고문 뜬다면

.gitattributes 파일

 *text=auto
 *.css text eol=lf
 *.js text eol=lf
 *.md text eol=lf

이렇게 설정 하시면 git add 하실 때 경고 안 나올 거에요! 혹시 경고 나오시는 분들은 저렇게 설정해보시고 안되시면 각자 운영체제에 맞게 설정해 주시면 됩니다!

유지보수를 생각해서 재사용 되는 폰트 크기 혹은 색상 정리 했습니다! 확인해 주시고 문제 되거나 수정 돼야한다고 생각 되는 부분들 알려주세요~!  